### PR TITLE
Fix/4395 learn more back redirection

### DIFF
--- a/app/src/androidTest/java/org/mozilla/focus/activity/AccessSettingsTest.java
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/AccessSettingsTest.java
@@ -7,7 +7,6 @@ package org.mozilla.focus.activity;
 
 import android.content.Context;
 import android.preference.PreferenceManager;
-
 import androidx.test.InstrumentationRegistry;
 import androidx.test.rule.ActivityTestRule;
 import androidx.test.runner.AndroidJUnit4;
@@ -110,7 +109,7 @@ public class AccessSettingsTest {
         try {
             searchHeading.click();
         } catch (UiObjectNotFoundException E) {
-            fail("Unable to find search heading on in settings menu");
+            fail("Unable to find search heading in settings menu");
         }
 
         try {

--- a/app/src/androidTest/java/org/mozilla/focus/activity/AccessSettingsTest.java
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/AccessSettingsTest.java
@@ -7,10 +7,12 @@ package org.mozilla.focus.activity;
 
 import android.content.Context;
 import android.preference.PreferenceManager;
+
 import androidx.test.InstrumentationRegistry;
 import androidx.test.rule.ActivityTestRule;
 import androidx.test.runner.AndroidJUnit4;
 import androidx.test.uiautomator.UiObject;
+import androidx.test.uiautomator.UiObjectNotFoundException;
 import androidx.test.uiautomator.UiSelector;
 
 import org.junit.After;
@@ -20,6 +22,7 @@ import org.junit.runner.RunWith;
 import org.mozilla.focus.helpers.TestHelper;
 
 import static junit.framework.Assert.assertTrue;
+import static junit.framework.Assert.fail;
 import static org.mozilla.focus.fragment.FirstrunFragment.FIRSTRUN_PREF;
 import static org.mozilla.focus.helpers.EspressoHelper.openSettings;
 import static org.mozilla.focus.helpers.TestHelper.waitingTime;
@@ -85,5 +88,39 @@ public class AccessSettingsTest {
         assertTrue(searchHeading.exists());
         assertTrue(privacyHeading.exists());
         assertTrue(mozHeading.exists());
+    }
+
+    @Test
+    public void BackRedirectionOnLearnMoreTest() {
+        UiObject searchHeading = TestHelper.mDevice.findObject(new UiSelector()
+                .text("Search")
+                .resourceId("android:id/title"));
+
+        UiObject learnMoreButton = TestHelper.mDevice.findObject(new UiSelector()
+                .text("Learn more"));
+
+        UiObject searchActionBar = TestHelper.mDevice.findObject(new UiSelector()
+                .text("Search"));
+
+        TestHelper.inlineAutocompleteEditText.waitForExists(waitingTime);
+        openSettings();
+
+        searchHeading.waitForExists(waitingTime);
+
+        try {
+            searchHeading.click();
+        } catch (UiObjectNotFoundException E) {
+            fail("Unable to find search heading on in settings menu");
+        }
+
+        try {
+            learnMoreButton.click();
+        } catch (UiObjectNotFoundException E) {
+            fail("Unable to find learn more button within Search submenu");
+        }
+
+        TestHelper.pressBackKey();
+        assertTrue(searchActionBar.exists());
+
     }
 }

--- a/app/src/main/java/org/mozilla/focus/settings/LearnMoreSwitchPreference.kt
+++ b/app/src/main/java/org/mozilla/focus/settings/LearnMoreSwitchPreference.kt
@@ -44,7 +44,6 @@ abstract class LearnMoreSwitchPreference(context: Context?, attrs: AttributeSet?
             val intent = InfoActivity.getIntentFor(context!!,
                     url, context.getString(R.string.enable_search_suggestion_subtitle_learnmore))
             context.startActivity(intent)
-            TelemetryWrapper.addSearchEngineLearnMoreEvent()
         }
 
         val backgroundDrawableArray =

--- a/app/src/main/java/org/mozilla/focus/settings/LearnMoreSwitchPreference.kt
+++ b/app/src/main/java/org/mozilla/focus/settings/LearnMoreSwitchPreference.kt
@@ -13,6 +13,10 @@ import android.widget.TextView
 import mozilla.components.browser.session.Session
 import org.mozilla.focus.R
 import org.mozilla.focus.ext.components
+import android.util.Log
+import org.mozilla.focus.activity.InfoActivity
+import org.mozilla.focus.telemetry.TelemetryWrapper
+import org.mozilla.focus.utils.SupportUtils
 
 abstract class LearnMoreSwitchPreference(context: Context?, attrs: AttributeSet?) :
     SwitchPreferenceCompat(context, attrs) {
@@ -36,15 +40,11 @@ abstract class LearnMoreSwitchPreference(context: Context?, attrs: AttributeSet?
         learnMoreLink.setOnClickListener {
             // This is a hardcoded link: if we ever end up needing more of these links, we should
             // move the link into an xml parameter, but there's no advantage to making it configurable now.
-            val session = Session(getLearnMoreUrl(), source = Session.Source.MENU)
-            context.components.sessionManager.add(session, selected = true)
-            if (context is ContextThemeWrapper) {
-                if ((context as ContextThemeWrapper).baseContext is Activity) {
-                    ((context as ContextThemeWrapper).baseContext as Activity).finish()
-                }
-            } else {
-                (context as? Activity)?.finish()
-            }
+            val url = getLearnMoreUrl()
+            val intent = InfoActivity.getIntentFor(context!!,
+                    url, context.getString(R.string.enable_search_suggestion_subtitle_learnmore))
+            context.startActivity(intent)
+            TelemetryWrapper.addSearchEngineLearnMoreEvent()
         }
 
         val backgroundDrawableArray =


### PR DESCRIPTION
Closes [#4395](https://github.com/mozilla-mobile/focus-android/issues/4395)

Changes:
The Learn More button on any page now follows same behaviour as for "i" icon for "Add search engine" option. That is, it goes back to the previous activity instead of MainActivity. Corresponding tests are included as well.
